### PR TITLE
Glossaryfix

### DIFF
--- a/XSLT/6x9book-real-poetry.xslt
+++ b/XSLT/6x9book-real-poetry.xslt
@@ -118,7 +118,7 @@
 \bibliocommand
 
 %	Glossary
-\printglossary
+\printglossaries
 
 
 %	Indexes
@@ -136,7 +136,8 @@
 		<xsl:text>\documentclass[10pt,twoside]{memoir}
 \usepackage{layouts}[2001/04/29]
 \usepackage{modified-bringhurst}   % Available from http://fletcherpenney.net/
-\makeglossary
+\usepackage{glossaries}
+\makeglossaries
 \makeindex
 \makeindex[firstlines]
 

--- a/XSLT/6x9book.xslt
+++ b/XSLT/6x9book.xslt
@@ -53,7 +53,8 @@
 	<xsl:template name="latex-document-class">
 		<xsl:text>\documentclass[10pt,twoside]{memoir}
 \usepackage{layouts}[2001/04/29]
-\makeglossary
+\usepackage{glossaries}
+\makeglossaries
 \makeindex
 
 \def\mychapterstyle{companion}

--- a/XSLT/letterhead.xslt
+++ b/XSLT/letterhead.xslt
@@ -292,7 +292,7 @@
 \bibliocommand
 
 %	Glossary
-\printglossary
+\printglossaries
 
 
 %	Index

--- a/XSLT/manuscript-novel.xslt
+++ b/XSLT/manuscript-novel.xslt
@@ -57,7 +57,7 @@
 \bibliocommand
 
 %	Glossary
-% \printglossary
+% \printglossaries
 
 
 %	Index
@@ -71,7 +71,8 @@
 		<xsl:text>\documentclass[10pt,oneside]{memoir}
 \usepackage{layouts}[2001/04/29]
 \usepackage{manuscript}
-\makeglossary
+\usepackage{glossaries}
+\makeglossaries
 \makeindex
 
 \def\revision{}

--- a/XSLT/memoir-natbib.xslt
+++ b/XSLT/memoir-natbib.xslt
@@ -50,8 +50,8 @@
 \usepackage{layouts}[2001/04/29]
 \usepackage[round,sort&amp;compress]{natbib}
 \setcitestyle{super,open={},close={},comma}
-
-\makeglossary
+\usepackage{glossaries}
+\makeglossaries
 \makeindex
 
 \def\mychapterstyle{default}

--- a/XSLT/memoir-twosided.xslt
+++ b/XSLT/memoir-twosided.xslt
@@ -51,7 +51,8 @@
 	<xsl:template name="latex-document-class">
 		<xsl:text>\documentclass[10pt,twoside]{memoir}
 \usepackage{layouts}[2001/04/29]
-\makeglossary
+\usepackage{glossaries}
+\makeglossaries
 \makeindex
 
 \def\mychapterstyle{default}

--- a/XSLT/memoir.xslt
+++ b/XSLT/memoir.xslt
@@ -45,10 +45,9 @@
 	</xsl:template>
 
 	<xsl:template name="latex-footer">
-		<xsl:text>%
-% Back Matter
-%
+		<xsl:text>
 
+% 	Back Matter
 \backmatter
 %\appendixpage
 
@@ -57,20 +56,22 @@
 \bibliocommand
 
 %	Glossary
-\printglossary
-
+\printglossaries
 
 %	Index
 \printindex
-
 \end{document}
+
 </xsl:text>
 	</xsl:template>
 
 	<xsl:template name="latex-document-class">
 		<xsl:text>\documentclass[10pt,oneside]{memoir}
 \usepackage{layouts}[2001/04/29]
-\makeglossary
+\usepackage{glossaries}
+\glstoctrue
+\makeglossaries
+
 \makeindex
 
 \def\mychapterstyle{default}
@@ -407,14 +408,29 @@
 
 	<!-- Memoir handles glossaries differently -->
 
+		<!-- this is slightly messy, but it works: extracts glossary term, and insert it into a \glsadd{} command -->
+
 	<xsl:template match="html:li" mode="glossary">
 		<xsl:param name="footnoteId"/>
 		<xsl:if test="parent::html:ol/parent::html:div/@class = 'footnotes'">
 			<xsl:if test="concat('#',@id) = $footnoteId">
 				<xsl:apply-templates select="html:span[@class='glossary sort']" mode="glossary"/>
 				<xsl:apply-templates select="html:span[@class='glossary name']" mode="glossary"/>
-				<xsl:text>{</xsl:text>
+				<xsl:variable name="glsname">
+					<xsl:apply-templates select="html:span[@class='glossary name']" mode="glossary"/>
+				</xsl:variable>
+				<xsl:text>,</xsl:text>
+				<xsl:text>description={</xsl:text>
 				<xsl:apply-templates select="html:p" mode="glossary"/>
+				<xsl:text>}} </xsl:text>
+				<xsl:variable name="glsbf">
+					<xsl:value-of select="substring-after($glsname,'{')"/>
+					</xsl:variable>
+				<xsl:variable name="glsclean">
+					<xsl:value-of select="substring-before($glsbf,'}')"/>
+					</xsl:variable>
+				<xsl:text>\glsadd{</xsl:text>
+				<xsl:value-of select="$glsclean"/>
 				<xsl:text>}</xsl:text>
 			</xsl:if>
 		</xsl:if>
@@ -424,8 +440,10 @@
 		<xsl:text>{</xsl:text>
 		<xsl:apply-templates select="node()"/>
 		<xsl:text>}</xsl:text>
+		<xsl:text>{</xsl:text>
+		<xsl:text>name=</xsl:text>
+		<xsl:apply-templates select="node()"/>
 	</xsl:template>
-	
 	<xsl:template match="html:span[@class='glossary sort']" mode="glossary">
 		<xsl:text>(</xsl:text>
 		<xsl:apply-templates select="node()"/>

--- a/XSLT/xhtml2latex.xslt
+++ b/XSLT/xhtml2latex.xslt
@@ -555,7 +555,7 @@
 			</xsl:when>
 
 			<xsl:when test="@class = 'footnote glossary'">
-				<xsl:text>\glossary</xsl:text>
+				<xsl:text>\newglossaryentry</xsl:text>
 				<xsl:apply-templates select="/html:html/html:body/html:div[@class]/html:ol/html:li[@id]" mode="glossary">
 					<xsl:with-param name="footnoteId" select="@href"/>
 				</xsl:apply-templates>

--- a/bin/MultiMarkdown/Support.pm
+++ b/bin/MultiMarkdown/Support.pm
@@ -145,10 +145,10 @@ sub ProcessMMD2PDF {
 	# These are not all necessary for simple files, but are included to try
 	# and be as thorough as possible...  Sort of a poor man's latexmk.pl
 	
-	my $tex_string = "; pdflatex mmd.tex; bibtex mmd; makeindex -t mmd.glg -o mmd.gls -s mmd.ist mmd.glo; makeindex -s `kpsewhich basic.gst` -o mmd.gls mmd.glo; pdflatex mmd.tex; pdflatex mmd.tex; pdflatex mmd.tex; pdflatex mmd.tex";
+	my $tex_string = "; pdflatex mmd.tex; bibtex mmd; makeglossaries mmd; pdflatex mmd.tex; pdflatex mmd.tex; pdflatex mmd.tex; pdflatex mmd.tex";
 
 	if ($^O =~ /MSWin/) {
-		$tex_string = "& pdflatex mmd.tex & bibtex mmd & makeindex -t mmd.glg -o mmd.gls -s mmd.ist mmd.glo & makeindex -s `kpsewhich basic.gst` -o mmd.gls mmd.glo & pdflatex mmd.tex & pdflatex mmd.tex & pdflatex mmd.tex & pdflatex mmd.tex";
+		$tex_string = "& pdflatex mmd.tex & bibtex mmd & makeglossaries mmd & pdflatex mmd.tex & pdflatex mmd.tex & pdflatex mmd.tex & pdflatex mmd.tex";
 	}	
 	PDFEngine($MMDPath, $input_file, $tex_string, $text);
 
@@ -163,10 +163,10 @@ sub ProcessMMD2PDFXeLaTeX {
 	# These are not all necessary for simple files, but are included to try
 	# and be as thorough as possible...  Sort of a poor man's latexmk.pl
 
-	my $tex_string = "; xelatex mmd.tex; bibtex mmd; makeindex -t mmd.glg -o mmd.gls -s mmd.ist mmd.glo; makeindex -s `kpsewhich basic.gst` -o mmd.gls mmd.glo; xelatex mmd.tex; xelatex mmd.tex; xelatex mmd.tex; xelatex mmd.tex";
+	my $tex_string = "; xelatex mmd.tex; bibtex mmd; makeglossaries mmd; xelatex mmd.tex; xelatex mmd.tex; xelatex mmd.tex; xelatex mmd.tex";
 
 	if ($^O =~ /MSWin/) {
-		$tex_string = "& xelatex mmd.tex & bibtex mmd & makeindex -t mmd.glg -o mmd.gls -s mmd.ist mmd.glo & makeindex -s `kpsewhich basic.gst` -o mmd.gls mmd.glo & xelatex mmd.tex & xelatex mmd.tex & xelatex mmd.tex & xelatex mmd.tex";
+		$tex_string = "& xelatex mmd.tex & bibtex mmd & makeglossaries mmd & xelatex mmd.tex & xelatex mmd.tex & xelatex mmd.tex & xelatex mmd.tex";
 	}
 	PDFEngine($MMDPath, $input_file, $tex_string, $text);
 }


### PR DESCRIPTION
This is a fix to re-enable support for glossaries in MMD. The main changes are in memoir.xslt, and in support.pm, where the makeindex and kpathsea commands have been replaced (in accordance with the 'glossaries' package documentation) with 'makeglossaries', which now handles all glossary processing. The glossaries package is included by default in TeX Live 2009 and 2010.
