### PR TITLE
Figure out paths via symlinks

### DIFF
--- a/bin/mmd2RTF.pl
+++ b/bin/mmd2RTF.pl
@@ -79,6 +79,12 @@ sub LocateMMD {
 	my $os = $^O;	# Mac = darwin; Linux = linux; Windows contains MSWin
 	my $MMDPath = "";
 
+  my $orig = cwd();
+
+  chdir(dirname($0));
+  if (readlink($0)) { chdir(dirname(readlink($0))); }
+  $me = ".";
+
 	# Determine where MMD is installed.  Use a "common installation"
 	# if available.
 
@@ -142,6 +148,8 @@ sub LocateMMD {
 
 	# Clean up the path
 	$MMDPath = abs_path($MMDPath);
+
+  chdir($orig);
 
 	return $MMDPath;
 }


### PR DESCRIPTION
I'm working on a homebrew (an osx package manager) recipe for MMD. They install into a private location and symlink into /usr/local/bin which causes problems with the LocateMMD function. This commit has a tentative patch in mmd2RTF.pl that seems to fix the issue. I wanted to run it by you before it got applied to all the scripts that need it. Let me know what you think. Thanks.

Once I get this issue resolved (and preferably pushed back into your repo), I'll submit the MMD recipe to homebrew for general distribution. Thanks for making a lovely tool that doesn't have 1400 dependencies. I appreciate it.
