### PR TITLE
Making footnotes compatible with picky CMSes

### DIFF
--- a/bin/MultiMarkdown.pl
+++ b/bin/MultiMarkdown.pl
@@ -1801,9 +1801,9 @@ sub _DoFootnotes {
 		if (defined $g_footnotes{$id} ) {
 			$g_footnote_counter++;
 			if ($g_footnotes{$id} =~ /^(<p>)?glossary:/i) {
-				$result = "<a href=\"#fn:$id\" id=\"fnref:$id\" title=\"see glossary\" class=\"footnote glossary\">$g_footnote_counter</a>";
+				$result = "<a name=\"fnref_$id\"></a><a href=\"#fn_$id\" title=\"see glossary\" class=\"footnote glossary\">$g_footnote_counter</a>";
 			} else {
-				$result = "<a href=\"#fn:$id\" id=\"fnref:$id\" title=\"see footnote\" class=\"footnote\">$g_footnote_counter</a>";
+				$result = "<a name=\"fnref_$id\"></a><a href=\"#fn_$id\" title=\"see footnote\" class=\"footnote\">$g_footnote_counter</a>";
 			}
 			push (@g_used_footnotes,$id);
 		}
@@ -1851,9 +1851,9 @@ sub _PrintFootnotes{
 				$glossary . ":<p>";	
 			}egsx;
 
-			$result.="<li id=\"fn:$id\">$footnote<a href=\"#fnref:$id\" title=\"return to article\" class=\"reversefootnote\">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n";
+			$result.="<li id=\"fn_$id\"><a name=\"fn_$id\"></a>$footnote<a href=\"#fnref_$id\" title=\"return to article\" class=\"reversefootnote\">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n";
 		} else {
-			$result.="<li id=\"fn:$id\">$footnote<a href=\"#fnref:$id\" title=\"return to article\" class=\"reversefootnote\">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n";
+			$result.="<li id=\"fn_$id\"><a name=\"fn_$id\"></a>$footnote<a href=\"#fnref_$id\" title=\"return to article\" class=\"reversefootnote\">&#160;&#8617;</a>$footnote_closing_tag</li>\n\n";
 		}
 	}
 	$result .= "</ol>\n</div>";
@@ -1878,7 +1878,7 @@ sub Header2Label {
 }
 
 sub id2footnote {
-	# Since we prepend "fn:", we can allow leading digits in footnotes
+	# Since we prepend "fn_", we can allow leading digits in footnotes
 	my $id = shift;
 	my $footnote = lc $id;
 	$footnote =~ s/[^A-Za-z0-9:_.-]//g;		# Strip illegal characters


### PR DESCRIPTION
Hi fletcher,

This is edge case, yes, but here's what's prompted me to patch MMdown. I use Notational Velocity (nvAlt) to write blog posts. I use MMdown w/ footnotes. I view the source and copy/paste it into posterous's html editor, and it takes the liberty of stripping out "id" attributes from the "li" footnote elements, and on top of that, chokes on the colons in the footnote ids.

This patch replaces colons with underscores. It also adds "a name=fn_footnoteid"-style anchors — which posterous accepts — in order to give the footnotes a proper link.

I absolutely love MMdown, thanks for all the hard work.

All best,
Nano
